### PR TITLE
Fix invocation with args

### DIFF
--- a/nyt.py
+++ b/nyt.py
@@ -195,7 +195,7 @@ def main():
             print(f"ERROR: Unknown browser '{browser}', please select one of:")
             for key in get_browsers():
                 print(f"  {key}")
-        exit(1)
+            exit(1)
     else:
         browser = pick_browser()
         url = input("Enter the NY Times crossword URL: ")


### PR DESCRIPTION
The three-arg invocation was always exiting(1). Trivial indentation fix.

Signed-off-by: Ed Santiago <ed@edsantiago.com>