### PR TITLE
Add Containerfile, with instructions in comments

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,18 @@
+#
+# Build: podman build -t nytxw .
+#
+# Run: podman run --rm -v $HOME/.mozilla:/root/.mozilla:Z,ro \
+#                 -v $HOME/path/to/nyt:/xw:Z \
+#                  nytxw Firefox \
+#                        $(date +'https://www.nytimes.com/crosswords/game/daily/%Y/%m/%d') \
+#                        /xw/$(date --iso-8601=date).puz
+#
+FROM docker.io/library/alpine:latest
+WORKDIR /nytxw_puz
+ADD *.py *.txt /nytxw_puz
+RUN apk update && \
+    apk add python3 py3-pip py3-wheel python3-dev gcc musl-dev libffi-dev zlib-dev rust cargo openssl-dev && \
+    python3 -m pip install -r requirements.txt && \
+    apk del py3-wheel python3-dev gcc musl-dev libffi-dev zlib-dev rust cargo openssl-dev && \
+    rm -rf /root/.cargo
+ENTRYPOINT ["/nytxw_puz/nyt.py"]


### PR DESCRIPTION
This builds a minimal-ish (130MB) container image. It is intended
to be run with two bind mounts: one, read-only, for browser cookies;
the other, writable, the directory into which to create the .puz file.

The Containerfile includes a sample invocation using Firefox. For
use with other browsers, change the .mozilla bind mount and the
first command-line argument as appropriate.

Signed-off-by: Ed Santiago <ed@edsantiago.com>