### PR TITLE
Use errors='namereplace', not string, when encoding

### DIFF
--- a/puz.py
+++ b/puz.py
@@ -35,7 +35,7 @@ MASKSTRING = 'ICHEATED'
 
 ENCODING = 'ISO-8859-1'
 ENCODING_UTF8 = 'UTF-8'
-ENCODING_ERRORS = 'strict'  # raises an exception for bad chars; change to 'replace' for laxer handling
+ENCODING_ERRORS = 'namereplace'  # e.g. '\N{EM DASH}'. Least-worst option.
 
 ACROSSDOWN = b'ACROSS&DOWN'
 


### PR DESCRIPTION
There aren't many options when source is UTF-8 and AcrossLite
is iso-8859-1. namereplace will at least show '\N{EM DASH}' for '—',
and so forth; I find that friendlier than '&#8212;' or '\u2014' or '?'.

Signed-off-by: Ed Santiago <ed@edsantiago.com>