### PR TITLE
Handle non-Latin-1 characters properly

### DIFF
--- a/nyt.py
+++ b/nyt.py
@@ -25,8 +25,8 @@ LATIN1_SUBS = {
     u"”": u'"',
     u"‘": u"'",
     u"’": u"'",
-    u"–": u"--",
-    u"—": u"---",
+    u"–": u"-",
+    u"—": u"--",
     u"…": u"...",
     u"№": u"No.",
     u"π": u"pi",
@@ -36,7 +36,13 @@ LATIN1_SUBS = {
     u"👆🏻": u"[emoji: hand pointing up]",
     u"🤘🏽": u"[emoji: hand with raised index and pinky finger]",
     u"✊🏿": u"[emoji: fist]",
-    u"ǐ": "i",
+    u"€": u"EUR",
+    u"•": u"*",
+    u"†": u"[dagger]",
+    u"‡": u"[dagger]",
+    u"™": u"[TM]",
+    u"‹": u"<",
+    u"›": u">",
 }
 
 
@@ -170,9 +176,14 @@ def print_puzzle(p):
 
 def latin1ify(s):
     # Make a Unicode string compliant with the Latin-1 (ISO-8859-1) character
-    # set; the Across Lite format only supports Latin-1 encoding
+    # set; the Across Lite v1.3 format only supports Latin-1 encoding
+
+    # Use our table to convert the most common Unicode glyphs
     for search, replace in LATIN1_SUBS.items():
         s = s.replace(search, replace)
+
+    # Convert anything remaining using replacements like '\N{EM DASH}'
+    s = s.encode('ISO-8859-1', 'namereplace').decode('ISO-8859-1')
     return s
 
 


### PR DESCRIPTION
Today's (Sep. 23, 2021) puzzle has a Unicode character (em dash, Unicode '\u2014') in some of the clues, which causes puz.py to throw an exception because the character is outside of Latin-1.

There are two ways to handle this. Method 1 is this pull request, which substitutes sensible Latin-1 alternatives for non-Latin-1 Unicode characters.

The second method would be to output puz files in the v2 format, which supports UTF-8 encodings. The version of puzpy you're using supports this. I haven't investigated how widely-supported the v2 format is; I'll do some further research. In the meantime this pull request addresses the issue.