### PR TITLE
Update Latin-1 conversion table

### DIFF
--- a/nyt.py
+++ b/nyt.py
@@ -20,29 +20,56 @@ TITLE_LINE = "\u2501"
 
 LATIN1_SUBS = {
     # For converting clues etc. into Latin-1 (ISO-8859-1) format;
-    # adapted from https://github.com/kberg/kpuz
-    u"“": u'"',
-    u"”": u'"',
-    u"‘": u"'",
-    u"’": u"'",
-    u"–": u"-",
-    u"—": u"--",
-    u"…": u"...",
-    u"№": u"No.",
-    u"π": u"pi",
-    u"🔥": u"[emoji: fire]",
-    u"🙈": u"[emoji: monkey with hands over eyes]",
-    u"👉🏾": u"[emoji: hand pointing right]",
-    u"👆🏻": u"[emoji: hand pointing up]",
-    u"🤘🏽": u"[emoji: hand with raised index and pinky finger]",
-    u"✊🏿": u"[emoji: fist]",
-    u"€": u"EUR",
-    u"•": u"*",
-    u"†": u"[dagger]",
-    u"‡": u"[dagger]",
-    u"™": u"[TM]",
-    u"‹": u"<",
-    u"›": u">",
+    # value None means let the encoder insert a Latin-1 equivalent
+    u'“': u'"',
+    u'”': u'"',
+    u'‘': u"'",
+    u'’': u"'",
+    u'–': u'-',
+    u'—': u'--',
+    u'…': u'...',
+    u'№': u'No.',
+    u'π': u'pi',
+    u'€': u'EUR',
+    u'•': u'*',
+    u'†': u'[dagger]',
+    u'‡': u'[double dagger]',
+    u'™': u'[TM]',
+    u'‹': u'<',
+    u'›': u'>',
+    u'←': u'<--',
+    u'■': None,
+    u'☐': None,
+    u'→': u'-->',
+    u'♣': None,
+    u'√': None,
+    u'♠': None,
+    u'✓': None,
+    u'♭': None,
+    u'♂': None,
+    u'★': u'*',
+    u'θ': u'theta',
+    u'β': u'beta',
+    u'Č': None,
+    u'𝚫': u'Delta',
+    u'❤︎': None,
+    u'✔': None,
+    u'⚓': None,
+    u'♦': None,
+    u'♥': None,
+    u'☹': None,
+    u'☮': None,
+    u'☘': None,
+    u'◯': None,
+    u'▢': None,
+    u'∑': None,
+    u'∃': None,
+    u'↓': None,
+    u'⁎': u'*',
+    u'η': u'eta',
+    u'α': u'alpha',
+    u'Ω': u'Omega',
+    u'ō': None,
 }
 
 
@@ -178,11 +205,12 @@ def latin1ify(s):
     # Make a Unicode string compliant with the Latin-1 (ISO-8859-1) character
     # set; the Across Lite v1.3 format only supports Latin-1 encoding
 
-    # Use our table to convert the most common Unicode glyphs
+    # Use table to convert the most common Unicode glyphs
     for search, replace in LATIN1_SUBS.items():
-        s = s.replace(search, replace)
+        if replace is not None:
+            s = s.replace(search, replace)
 
-    # Convert anything remaining using replacements like '\N{EM DASH}'
+    # Convert anything remaining using replacements like '\N{WINKING FACE}'
     s = s.encode('ISO-8859-1', 'namereplace').decode('ISO-8859-1')
     return s
 


### PR DESCRIPTION
Great list @Q726kbXuN that you compiled at [glyph_counts.txt](https://github.com/Q726kbXuN/nytxw_puz/files/7221236/glyph_counts.txt). Very interesting to see the frequency of unusual characters in NYT crosswords.

I dropped your list as-is into the code, but removed:
- Glyphs from u0000-u00ff inclusive, since these are valid Latin-1, and
- Emojis, since the encoder's replacements like \N{WINKING FACE} are as good as anything I could come up with.

So this is apparently every non-Latin-1, non-emoji character ever used in a NYT puzzle. A value of 'None' in the table causes the encoder to insert its own replacement. I put in conversions where I could think of something decent, but clearly this is more art than science so please feel free to edit. :)