### PR TITLE
py2exe: only require if on Windows

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ keyring==23.2.1
 lz4==3.1.3
 pbkdf2==1.3
 pefile==2021.9.3
-py2exe==0.10.4.1
+py2exe==0.10.4.1; sys_platform == 'win32'
 pyaes==1.6.1
 pycparser==2.20
 pycryptodome==3.10.1


### PR DESCRIPTION
...otherwise, installation raises 'RuntimeError: This package requires Windows'

Signed-off-by: Ed Santiago <ed@edsantiago.com>