### PR TITLE
Add support for puzzle notes

### DIFF
--- a/nyt.py
+++ b/nyt.py
@@ -289,6 +289,11 @@ def data_to_puz(puzzle):
             if 'type' in cell and cell['type'] == NYT_TYPE_CIRCLED:
                 markup.markup[cell['index']] = puz.GridMarkup.Circled
 
+    # Check for any notes in puzzle (e.g., Sep 11, 2008)
+    if 'notes' in data['meta']:
+        p.notes = '\n\n'.join(x['text'] for x in data['meta']['notes']
+                              if 'text' in x)
+
     # All done
     return p
 


### PR DESCRIPTION
This change checks if the puzzle contains any solving notes, and adds them to the output's 'notes' field.

Solving notes are not uncommon in themed puzzles. Example:
`nyt.py Chrome https://www.nytimes.com/crosswords/game/daily/2008/09/11 Sep1108.puz`

Note about notes: When the NYT was publishing in .puz format, they would often put notes into the puzzle **title**. For example [here](https://github.com/alexdej/puzpy/blob/ae71d58fc3b9646d6db9199de3dc634c1e90435e/testfiles/nyt_rebus_with_notes_and_shape.puz) is their own published version of the above Sep 11, 2008 puzzle. (In the JSON version this actually contains two notes; in the published .puz file one ended up in the title and the other in the notes field.) I'm guessing they did this for compatibility in case software ignored the notes field. However the solvers I've tested (macOS Black Ink and downforacross.com) both handle notes properly so I'm disinclined to put them in the title.