### PR TITLE
Render gray cells as circles, bug fixes

### DIFF
--- a/nyt.py
+++ b/nyt.py
@@ -308,7 +308,7 @@ def data_to_puz(puzzle):
 
     # Check for any notes in puzzle (e.g., Sep 11, 2008)
     if 'notes' in data['meta']:
-        p.notes = '\n\n'.join(x['text'] for x in data['meta']['notes']
+        p.notes = '\n\n'.join(latin1ify(x['text']) for x in data['meta']['notes']
                               if 'text' in x)
 
     # All done

--- a/nyt.py
+++ b/nyt.py
@@ -298,12 +298,12 @@ def data_to_puz(puzzle):
                 rebus.add_rebus(None)
 
     # See if any grid squares are marked up with circles
-    if any(x['type'] == NYT_TYPE_CIRCLED for x in data['cells'] if 'type' in x):
+    if any(x['type'] in (NYT_TYPE_CIRCLED, NYT_TYPE_GRAY) for x in data['cells'] if 'type' in x):
         markup = p.markup()
         markup.markup = [0] * (p.width * p.height)
 
         for cell in data['cells']:
-            if 'type' in cell and cell['type'] == NYT_TYPE_CIRCLED:
+            if 'type' in cell and cell['type'] in (NYT_TYPE_CIRCLED, NYT_TYPE_GRAY):
                 markup.markup[cell['index']] = puz.GridMarkup.Circled
 
     # Check for any notes in puzzle (e.g., Sep 11, 2008)

--- a/puz.py
+++ b/puz.py
@@ -624,7 +624,7 @@ class Markup:
         return [i for i, b in enumerate(self.markup) if b]
 
     def is_markup_square(self, index):
-        return bool(self.table[index])
+        return bool(self.markup[index])
 
     def save(self):
         if self.has_markup():


### PR DESCRIPTION
Today's puzzle (Oct 17, 2021) has some cells with gray shading applied, which is currently ignored since the .puz format doesn't support it. In this case the shading is meaningful to solving the puzzle. This change renders gray cells as circles, which isn't ideal but IMHO the best option within the constraints of the format.

Also a few minor bugfixes, one of which was to puzpy and has been [fixed](https://github.com/alexdej/puzpy/pull/28) upstream.