### PR TITLE
py2exe: require it only on win32

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ keyring==23.5.0
 lz4==4.0.0
 pbkdf2==1.3
 pefile==2021.9.3
-py2exe==0.11.1.0
+py2exe==0.11.1.0; sys_platform == 'win32'
 pyaes==1.6.1
 pycparser==2.21
 pycryptodome==3.14.1


### PR DESCRIPTION
Oops, this got lost in 636a52e

Signed-off-by: Ed Santiago <ed@edsantiago.com>