### PR TITLE
Check for interactive session before keyboard input

### DIFF
--- a/nyt.py
+++ b/nyt.py
@@ -562,7 +562,7 @@ def main():
         output = data_to_puz(puzzle)
         output.save(os.path.expanduser(output_fn))
         print(f"Created {output_fn}")
-        if sys.platform == 'darwin':
+        if sys.platform == 'darwin' and hasattr(sys, 'ps1'):
             input("Press enter to continue...")
     except:
         print("ERROR! " * 10)
@@ -573,7 +573,8 @@ def main():
         print("")
         print("Please report issues to https://www.reddit.com/user/nobody514/")
         print("")
-        input("Press enter to continue...")
+        if hasattr(sys, 'ps1'):
+            input("Press enter to continue...")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This change allows `nyt.py` to run as a non-interactive script without error. `hasattr(sys, 'ps1')` appears to be the most general way to tell if running in interactive mode ([thread](https://stackoverflow.com/questions/2356399/tell-if-python-is-in-interactive-mode)).

Thank you for the code! I use it every day.